### PR TITLE
Add .NET Core support

### DIFF
--- a/dspatch/Nitro/ARM9.cs
+++ b/dspatch/Nitro/ARM9.cs
@@ -153,19 +153,30 @@ namespace dspatch.Nitro
 			return (uint)IndexOf(Data, new byte[] { 0x21, 0x06, 0xC0, 0xDE, 0xDE, 0xC0, 0x06, 0x21 }) - 0x1C;
 		}
 
-		private static unsafe long IndexOf(byte[] Data, byte[] Search)
+		private static long IndexOf(byte[] Data, byte[] Search)
 		{
-			fixed (byte* H = Data) fixed (byte* N = Search)
+			long MaxOffset = Data.LongLength - Search.LongLength + 1;
+			if (MaxOffset <= 0)
 			{
-				long i = 0;
-				for (byte* hNext = H, hEnd = H + Data.LongLength; hNext < hEnd; i++, hNext++)
-				{
-					bool Found = true;
-					for (byte* hInc = hNext, nInc = N, nEnd = N + Search.LongLength; Found && nInc < nEnd; Found = *nInc == *hInc, nInc++, hInc++) ;
-					if (Found) return i;
-				}
-				return -1;
+				throw new ArgumentOutOfRangeException(nameof(Search));
 			}
+
+			for (long Offset = 0; Offset < MaxOffset; Offset++)
+			{
+				bool Found = true;
+				for (long patternOffset = 0; patternOffset < Search.LongLength; patternOffset++)
+				{
+					if (Data[Offset + patternOffset] != Search[patternOffset])
+					{
+						Found = false;
+						break;
+					}
+				}
+
+				if (Found) return Offset;
+			}
+
+			throw new Exception("No target module params offset found!");
 		}
 	}
 }

--- a/dspatch/dspatch-core.csproj
+++ b/dspatch/dspatch-core.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>dspatch</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\**" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This lets dspatch run under Linux/macOS natively with .NET Core instead of Mono. Do `dotnet build dspatch-core.csproj` next to that .csproj and that's it.

The unsafe block initially threw a build warning and looked a bit magical so I quickly replaced it but it's not really required for anything, other than looking nicer - I can get rid of that if you'd prefer the original code.